### PR TITLE
Extra Whitespace Bug-Fix

### DIFF
--- a/PrettyPrinter.class.nut
+++ b/PrettyPrinter.class.nut
@@ -106,7 +106,6 @@ class PrettyPrinter {
         
         while (i < len) {
             char = json[i];
-        // foreach (char in json) {
             if (char == '"' && prev != '\\') {
                 // End of quoted string
                 inQuotes = !inQuotes;
@@ -128,7 +127,7 @@ class PrettyPrinter {
                 }
                 // Move to the next line and add indentation
                 r += "\n" + _repeat(_indentStr, pos);
-                // skip the next character, it is a space added by the json encoder
+                // Skip the next character, it is a space added by the json encoder
                 i++;
             }
      

--- a/PrettyPrinter.class.nut
+++ b/PrettyPrinter.class.nut
@@ -32,12 +32,21 @@ class PrettyPrinter {
      * @param {string} json - JSON encoded string
      */
     function _prettify(json) {
-        local r = ""; // Result string
-        local pos = 0; // Level of indentation
+        local i = 0; // Position in the input string
+        local pos = 0; // Current level of indentation
+        
+        local char = null; // Current character
         local prev = null; // Previous character
+        
         local inQuotes = false; // Are we inside a pair of quotes?
         
-        foreach (char in json) {
+        local r = ""; // Result string
+        
+        local len = json.len();
+        
+        while (i < len) {
+            char = json[i];
+        // foreach (char in json) {
             if (char == '"' && prev != '\\') {
                 // End of quoted string
                 inQuotes = !inQuotes;
@@ -59,9 +68,12 @@ class PrettyPrinter {
                 }
                 // Move to the next line and add indentation
                 r += "\n" + _repeat(_indentStr, pos);
+                // skip the next character, it is a space added by the json encoder
+                i++;
             }
      
             prev = char;
+            i++;
         }
         
         return r;

--- a/test/TestRunner.class.nut
+++ b/test/TestRunner.class.nut
@@ -14,11 +14,11 @@ class TestRunner {
         char = 'A';
         
         string = @"I am a big string,
-        With Multiple lines...
+With Multiple lines...
         
-        ""A quote"" - someone
+""A quote"" - someone
         
-            some indentation too."
+    some indentation too."
             
         table = {
             "key1": "value1",
@@ -64,8 +64,8 @@ class TestRunner {
     function run() {
         server.log("RUNNING TESTS");
         
+        // PP.print(array);
         // PP.print(nested);
-        PP.print(nested, false);
         // PP.print(deepNested)
         // PP.print(deepNested, false);
         


### PR DESCRIPTION
This update skips the space characters added by the JSON encoder, which was causing an extra space character to be included on some lines of the output.
