### PR TITLE
Fix inconsistent printing between JSON encoders

### DIFF
--- a/PrettyPrinter.class.nut
+++ b/PrettyPrinter.class.nut
@@ -1,7 +1,7 @@
 /** Class for pretty-printing squirrel objects */
 class PrettyPrinter {
 
-    static version = [1, 0, 0];
+    static version = [1, 0, 1];
 
     _indentStr = null;
     _truncate = null;
@@ -106,6 +106,7 @@ class PrettyPrinter {
         
         while (i < len) {
             char = json[i];
+            
             if (char == '"' && prev != '\\') {
                 // End of quoted string
                 inQuotes = !inQuotes;
@@ -115,6 +116,12 @@ class PrettyPrinter {
                 pos--;
                 // Move to the next line and add indentation
                 r += "\n" + _repeat(_indentStr, pos);
+                
+            } else if (char == ' ' && !inQuotes) {
+                // Skip any spaces added by the JSON encoder
+                i++;
+                continue;
+                
             }
             
             // Push the current character
@@ -127,8 +134,9 @@ class PrettyPrinter {
                 }
                 // Move to the next line and add indentation
                 r += "\n" + _repeat(_indentStr, pos);
-                // Skip the next character, it is a space added by the json encoder
-                i++;
+            } else if (char == ':' && !inQuotes) {
+                // Add a space between table keys and values
+                r += " ";
             }
      
             prev = char;

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ On the device, this library is dependent on the [JSONEncoder library](https://gi
 
 #### Agent Code
 
-**To add this library to your project, add** `#require "PrettyPrinter.class.nut:1.0.0"` **to the top of your agent code**.
+**To add this library to your project, add** `#require "PrettyPrinter.class.nut:1.0.1"` **to the top of your agent code**.
 
 #### Device Code
 
-**To add this library to your project, add** `#require "PrettyPrinter.class.nut:1.0.0"` **and** `#require "JSONEncoder.class.nut:1.0.0"` **to the top of your device code**.
+**To add this library to your project, add** `#require "PrettyPrinter.class.nut:1.0.1"` **and** `#require "JSONEncoder.class.nut:1.0.0"` **to the top of your device code**.
 
 ## Class Usage
 


### PR DESCRIPTION
There was an inconsistency in output due to the different JSON encoders adding their own white-space differently.  This change ignores any white-space added by the JSON encoders, then adds its own if and when required, and bumps the version number.
