### PR TITLE
Change JSONEncoder version and add Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,30 @@ On the device, this library is dependent on the [JSONEncoder library](https://gi
 
 #### Device Code
 
-**To add this library to your project, add** `#require "PrettyPrinter.class.nut:1.0.1"` **and** `#require "JSONEncoder.class.nut:1.0.1"` **to the top of your device code**.
+**To add this library to your project, add** `#require "PrettyPrinter.class.nut:1.0.1"` **and** `#require "JSONEncoder.class.nut:1.0.0"` **to the top of your device code**.
 
 ## Class Usage
+
+### Quick Start
+
+To define a global function `print`, which logs its input without truncation, use the following.
+
+```squirrel
+// null to use default string for indentation, false to force printing
+// objects in full, without truncation
+pp <- PrettyPrinter(null, false);
+print <- pp.print.bindenv(pp);
+
+// example usage
+::print([1,2,3]);
+/*
+[
+    1,
+    2,
+    3
+]
+*/
+```
 
 ### Constructor: PrettyPrinter(*[indentString, truncate]*)
 


### PR DESCRIPTION
JSONEncoder v1.0.1 does not yet exist.  Added an example of defining a global print function, which reflects the way I have been using the class.
